### PR TITLE
Faster packet using u64 zero-cost reference change

### DIFF
--- a/tpx3/Cargo.toml
+++ b/tpx3/Cargo.toml
@@ -22,3 +22,4 @@ debug = true
 #debuginfo-level=1
 lto = "thin"
 codegen-units=1
+panic = "abort"

--- a/tpx3/src/auxiliar.rs
+++ b/tpx3/src/auxiliar.rs
@@ -498,7 +498,7 @@ pub mod misc {
 pub mod value_types {
     pub type POSITION = u32;
     pub type COUNTER = u32;
-    pub type TIME = usize;
+    pub type TIME = u64;
 }
 
 pub mod compressing {

--- a/tpx3/src/bin/debug_isi.rs
+++ b/tpx3/src/bin/debug_isi.rs
@@ -1,18 +1,17 @@
-use timepix3::tdclib::isi_box::{CHANNELS, IsiBoxTools, IsiBoxHand};
-use timepix3::postlib::isi_box;
+//use timepix3::tdclib::isi_box::{CHANNELS, IsiBoxTools, IsiBoxHand};
+//use timepix3::postlib::isi_box;
 use timepix3::postlib::coincidence::*;
 use timepix3::auxiliar::ConfigAcquisition;
 use std::env;
-use timepix3::isi_box_new;
-use std::{thread, time};
-use std::fs::File;
+//use timepix3::isi_box_new;
+//use std::{thread, time};
+//use std::fs::File;
 
 fn main() {
     //Only IsiBox
     //let f = File::open("isi_raw239.isi").unwrap();
     //isi_box::get_channel_timelist(f);
     
-    ///*
     let args: Vec<String> = env::args().collect();
     let config_set = ConfigAcquisition::new(&args[0..6]);
     let mut coinc_data = ElectronData::new(&config_set);
@@ -28,7 +27,6 @@ fn main() {
     coinc_data.output_non_dispersive();
     coinc_data.output_spim_index();
     coinc_data.output_tot();
-    //*/
 
 
     /*

--- a/tpx3/src/packetlib.rs
+++ b/tpx3/src/packetlib.rs
@@ -3,7 +3,7 @@
 
 use crate::auxiliar::value_types::*;
 
-fn packet_change(v: &[u8]) -> &[u64] {
+pub fn packet_change(v: &[u8]) -> &[u64] {
     unsafe {
         std::slice::from_raw_parts(
             v.as_ptr() as *const u64,
@@ -13,11 +13,11 @@ fn packet_change(v: &[u8]) -> &[u64] {
 
 pub trait Packet {
     fn ci(&self) -> u8;
-    fn data(&self) -> &[u8];
+    fn data(&self) -> &[u64];
     fn x(&self) -> POSITION {
         //let temp = ((self.data()[6] & 224)>>4 | (self.data()[7] << 4) | ((self.data()[5] & 112) >> 6)) as POSITION;
-        let val = packet_change(self.data())[0];
-        let temp2 = (((val & 0x0F_E0_00_00_00_00_00_00) >> 52) | ((val & 0x00_00_40_00_00_00_00_00) >> 46)) as POSITION;
+        //let val = packet_change(self.data())[0];
+        let temp2 = (((self.data()[0] & 0x0F_E0_00_00_00_00_00_00) >> 52) | ((self.data()[0] & 0x00_00_40_00_00_00_00_00) >> 46)) as POSITION;
         //assert_eq!(temp, temp2 as u32);
         //let temp2 = (val & 0x0F_E0_00_00_00_00_00_00) >> 52;
         //println!("{:?} and {:?} and {:?}", temp, temp2, (self.data()[7] << 4) | ((self.data()[6] & 224) >> 4));
@@ -35,18 +35,22 @@ pub trait Packet {
     
     fn x_raw(&self) -> POSITION {
         let x = (((self.data()[6] & 224)>>4 | (self.data()[7] & 15)<<4) | ((self.data()[5] & 64)>>6)) as POSITION;
+        //let val = packet_change(self.data())[0];
+        let x2 = (((self.data()[0] & 0x0F_E0_00_00_00_00_00_00) >> 52) | ((self.data()[0] & 0x00_00_40_00_00_00_00_00) >> 46)) as POSITION;
+        assert_eq!(x, x2 as u32);
         x
     }
     
     fn y(&self) -> POSITION {
         //let y = (   ( (self.data()[5] & 128)>>5 | (self.data()[6] & 31)<<3 ) | ( ((self.data()[5] & 112)>>4) & 3 )   ) as POSITION;
-        let val = packet_change(self.data())[0];
-        let y2 = ((val & 0x00_1F_80_00_00_00_00_00) >> 45) | ((val & 0x00_00_30_00_00_00_00_00) >> 44);
+        //let val = packet_change(self.data())[0];
+        let y2 = ((self.data()[0] & 0x00_1F_80_00_00_00_00_00) >> 45) | ((self.data()[0] & 0x00_00_30_00_00_00_00_00) >> 44);
         //assert_eq!(y, y2 as u32);
 
         y2 as POSITION
     }
 
+    /*
     fn x_y(&self) -> (POSITION, POSITION) {
         let dcol = (self.data()[6] & 224)>>4 | (self.data()[7] << 4);
         let spix = (self.data()[5] & 128) >> 5 | (self.data()[6] & 31) << 3;
@@ -63,52 +67,54 @@ pub trait Packet {
             _ => panic!("More than four CIs."),
         }
     }
+    */
 
     #[inline]
     fn id(&self) -> u8 {
-        let val = packet_change(self.data())[0];
-        let id2 = (val & 0xF0_00_00_00_00_00_00_00) >> 60;
-        assert_eq!(id2 as u8, (self.data()[7] & 240) >> 4);
-        (self.data()[7] & 240) >> 4
+        //let val = packet_change(self.data())[0];
+        let id2 = (self.data()[0] & 0xF0_00_00_00_00_00_00_00) >> 60;
+        //assert_eq!(id2 as u8, (self.data()[7] & 240) >> 4);
+        //(self.data()[7] & 240) >> 4
+        id2 as u8
     }
 
     #[inline]
     fn spidr(&self) -> TIME {
-        let val = packet_change(self.data())[0];
-        let spidr2 = val & 0x00_00_00_00_00_00_FF_FF;
-        let spidr = (self.data()[0] as TIME) | (self.data()[1] as TIME) << 8;
-        assert_eq!(spidr, spidr2 as usize);
-        spidr
+        //let val = packet_change(self.data())[0];
+        let spidr2 = self.data()[0] & 0x00_00_00_00_00_00_FF_FF;
+        //let spidr = (self.data()[0] as TIME) | (self.data()[1] as TIME) << 8;
+        //assert_eq!(spidr, spidr2 as usize);
+        spidr2 as usize
 
     }
 
     #[inline]
     fn ftoa(&self) -> TIME {
-        let ftoa = (self.data()[2] & 15) as TIME;
-        let val = packet_change(self.data())[0];
-        let ftoa2 = (val & 0x00_00_00_00_00_0F_00_00) >> 16;
-        assert_eq!(ftoa, ftoa2 as usize);
-        ftoa
+        //let ftoa = (self.data()[2] & 15) as TIME;
+        //let val = packet_change(self.data())[0];
+        let ftoa2 = (self.data()[0] & 0x00_00_00_00_00_0F_00_00) >> 16;
+        //assert_eq!(ftoa, ftoa2 as usize);
+        ftoa2 as TIME
 
     }
 
     #[inline]
     fn tot(&self) -> u16 {
-        let tot = ((self.data()[2] & 240) as u16)>>4 | ((self.data()[3] & 63) as u16)<<4;
-        let val = packet_change(self.data())[0];
-        let tot2 = (val & 0x00_00_00_00_3F_F0_00_00) >> 20;
-        assert_eq!(tot, tot2 as u16);
-        tot
+        //let tot = ((self.data()[2] & 240) as u16)>>4 | ((self.data()[3] & 63) as u16)<<4;
+        //let val = packet_change(self.data())[0];
+        let tot2 = (self.data()[0] & 0x00_00_00_00_3F_F0_00_00) >> 20;
+        //assert_eq!(tot, tot2 as u16);
+        tot2 as u16
 
     }
 
     #[inline]
     fn toa(&self) -> TIME {
-        let toa = ((self.data()[3] >> 6) as TIME) | (self.data()[4] as TIME)<<2 | ((self.data()[5] & 15) as TIME)<<10;
-        let val = packet_change(self.data())[0];
-        let toa2 = (val & 0x00_00_0F_FF_C0_00_00_00) >> 30;
-        assert_eq!(toa, toa2 as usize);
-        toa
+        //let toa = ((self.data()[3] >> 6) as TIME) | (self.data()[4] as TIME)<<2 | ((self.data()[5] & 15) as TIME)<<10;
+        //let val = packet_change(self.data())[0];
+        let toa2 = (self.data()[0] & 0x00_00_0F_FF_C0_00_00_00) >> 30;
+        //assert_eq!(toa, toa2 as usize);
+        toa2 as TIME
     }
 
     #[inline]
@@ -136,38 +142,38 @@ pub trait Packet {
 
     #[inline]
     fn tdc_coarse(&self) -> TIME {
-        let tdc_coarse = ((self.data()[1] & 254) as TIME)>>1 | ((self.data()[2]) as TIME)<<7 | ((self.data()[3]) as TIME)<<15 | ((self.data()[4]) as TIME)<<23 | ((self.data()[5] & 15) as TIME)<<31;
-        let val = packet_change(self.data())[0];
-        let tdc_coarse2 = (val & 0x00_00_0F_FF_FF_FF_FE_00) >> 9;
-        assert_eq!(tdc_coarse, tdc_coarse2 as usize);
-        tdc_coarse
+        //let tdc_coarse = ((self.data()[1] & 254) as TIME)>>1 | ((self.data()[2]) as TIME)<<7 | ((self.data()[3]) as TIME)<<15 | ((self.data()[4]) as TIME)<<23 | ((self.data()[5] & 15) as TIME)<<31;
+        //let val = packet_change(self.data())[0];
+        let tdc_coarse2 = (self.data()[0] & 0x00_00_0F_FF_FF_FF_FE_00) >> 9;
+        //assert_eq!(tdc_coarse, tdc_coarse2 as usize);
+        tdc_coarse2 as TIME
     }
     
     #[inline]
     fn tdc_fine(&self) -> TIME {
-        let tdc_fine = ((self.data()[0] & 224) as TIME >> 5) | ((self.data()[1] & 1) as TIME) << 3;
-        let val = packet_change(self.data())[0];
-        let tdc_fine2 = (val & 0x00_00_00_00_00_00_01_E0) >> 5;
-        assert_eq!(tdc_fine, tdc_fine2 as usize);
-        tdc_fine
+        //let tdc_fine = ((self.data()[0] & 224) as TIME >> 5) | ((self.data()[1] & 1) as TIME) << 3;
+        //let val = packet_change(self.data())[0];
+        let tdc_fine2 = (self.data()[0] & 0x00_00_00_00_00_00_01_E0) >> 5;
+        //assert_eq!(tdc_fine, tdc_fine2 as usize);
+        tdc_fine2 as TIME
     }
 
     #[inline]
     fn tdc_counter(&self) -> u16 {
-        let counter = ((self.data()[5] & 240) as u16) >> 4 | (self.data()[6] as u16) << 4;
-        let val = packet_change(self.data())[0];
-        let counter2 = (val & 0x00_FF_F0_00_00_00_00_00) >> 44;
-        assert_eq!(counter, counter2 as u16);
-        counter
+        //let counter = ((self.data()[5] & 240) as u16) >> 4 | (self.data()[6] as u16) << 4;
+        //let val = packet_change(self.data())[0];
+        let counter2 = (self.data()[0] & 0x00_FF_F0_00_00_00_00_00) >> 44;
+        //assert_eq!(counter, counter2 as u16);
+        counter2 as u16
     }
 
     #[inline]
     fn tdc_type(&self) -> u8 {
-        let tdc_type = self.data()[7] & 15 ;
-        let val = packet_change(self.data())[0];
-        let tdc_type2 = (val & 0x0F_00_00_00_00_00_00_00) >> 56;
-        assert_eq!(tdc_type, tdc_type2 as u8);
-        tdc_type
+        //let tdc_type = self.data()[7] & 15 ;
+        //let val = packet_change(self.data())[0];
+        let tdc_type2 = (self.data()[0] & 0x0F_00_00_00_00_00_00_00) >> 56;
+        //assert_eq!(tdc_type, tdc_type2 as u8);
+        tdc_type2 as u8
     }
 
     #[inline]
@@ -215,14 +221,14 @@ pub trait Packet {
 
 pub struct PacketEELS<'a> {
     pub chip_index: u8,
-    pub data: &'a [u8],
+    pub data: &'a [u64],
 }
 
 impl<'a> Packet for PacketEELS<'a> {
     fn ci(&self) -> u8 {
         self.chip_index
     }
-    fn data(&self) -> &[u8] {
+    fn data(&self) -> &[u64] {
         self.data
     }
 }
@@ -235,14 +241,14 @@ impl<'a> PacketEELS<'a> {
 
 pub struct TimeCorrectedPacketEELS<'a> {
     pub chip_index: u8,
-    pub data: &'a [u8; 8],
+    pub data: &'a [u64],
 }
 
 impl<'a> Packet for TimeCorrectedPacketEELS<'a> {
     fn ci(&self) -> u8 {
         self.chip_index
     }
-    fn data(&self) -> &[u8] {
+    fn data(&self) -> &[u64] {
         self.data
     }
     
@@ -272,14 +278,14 @@ impl<'a> TimeCorrectedPacketEELS<'a> {
 
 pub struct PacketDiffraction<'a> {
     pub chip_index: u8,
-    pub data: &'a [u8],
+    pub data: &'a [u64],
 }
 
 impl<'a> Packet for PacketDiffraction<'a> {
     fn ci(&self) -> u8 {
         self.chip_index
     }
-    fn data(&self) -> &[u8] {
+    fn data(&self) -> &[u64] {
         self.data
     }
     fn x(&self) -> POSITION {

--- a/tpx3/src/packetlib.rs
+++ b/tpx3/src/packetlib.rs
@@ -13,17 +13,9 @@ pub fn packet_change(v: &[u8]) -> &[u64] {
 
 pub trait Packet {
     fn ci(&self) -> u8;
-    fn data(&self) -> &[u64];
+    fn data(&self) -> u64;
     fn x(&self) -> POSITION {
-        //let temp = ((self.data()[6] & 224)>>4 | (self.data()[7] << 4) | ((self.data()[5] & 112) >> 6)) as POSITION;
-        //let val = packet_change(self.data())[0];
-        let temp2 = (((self.data()[0] & 0x0F_E0_00_00_00_00_00_00) >> 52) | ((self.data()[0] & 0x00_00_40_00_00_00_00_00) >> 46)) as POSITION;
-        //assert_eq!(temp, temp2 as u32);
-        //let temp2 = (val & 0x0F_E0_00_00_00_00_00_00) >> 52;
-        //println!("{:?} and {:?} and {:?}", temp, temp2, (self.data()[7] << 4) | ((self.data()[6] & 224) >> 4));
-        //let temp = self.data()[0] & 
-        //(!temp & 255) | (temp & 768)
-
+        let temp2 = (((self.data() & 0x0F_E0_00_00_00_00_00_00) >> 52) | ((self.data() & 0x00_00_40_00_00_00_00_00) >> 46)) as POSITION;
         match self.ci() {
             0 => 255 - temp2,
             1 => 256 * 4 - 1 - temp2,
@@ -34,20 +26,11 @@ pub trait Packet {
     }
     
     fn x_raw(&self) -> POSITION {
-        let x = (((self.data()[6] & 224)>>4 | (self.data()[7] & 15)<<4) | ((self.data()[5] & 64)>>6)) as POSITION;
-        //let val = packet_change(self.data())[0];
-        let x2 = (((self.data()[0] & 0x0F_E0_00_00_00_00_00_00) >> 52) | ((self.data()[0] & 0x00_00_40_00_00_00_00_00) >> 46)) as POSITION;
-        assert_eq!(x, x2 as u32);
-        x
+        (((self.data() & 0x0F_E0_00_00_00_00_00_00) >> 52) | ((self.data() & 0x00_00_40_00_00_00_00_00) >> 46)) as POSITION
     }
     
     fn y(&self) -> POSITION {
-        //let y = (   ( (self.data()[5] & 128)>>5 | (self.data()[6] & 31)<<3 ) | ( ((self.data()[5] & 112)>>4) & 3 )   ) as POSITION;
-        //let val = packet_change(self.data())[0];
-        let y2 = ((self.data()[0] & 0x00_1F_80_00_00_00_00_00) >> 45) | ((self.data()[0] & 0x00_00_30_00_00_00_00_00) >> 44);
-        //assert_eq!(y, y2 as u32);
-
-        y2 as POSITION
+        (((self.data() & 0x00_1F_80_00_00_00_00_00) >> 45) | ((self.data() & 0x00_00_30_00_00_00_00_00) >> 44)) as POSITION
     }
 
     /*
@@ -71,50 +54,27 @@ pub trait Packet {
 
     #[inline]
     fn id(&self) -> u8 {
-        //let val = packet_change(self.data())[0];
-        let id2 = (self.data()[0] & 0xF0_00_00_00_00_00_00_00) >> 60;
-        //assert_eq!(id2 as u8, (self.data()[7] & 240) >> 4);
-        //(self.data()[7] & 240) >> 4
-        id2 as u8
+        ((self.data() & 0xF0_00_00_00_00_00_00_00) >> 60) as u8
     }
 
     #[inline]
     fn spidr(&self) -> TIME {
-        //let val = packet_change(self.data())[0];
-        let spidr2 = self.data()[0] & 0x00_00_00_00_00_00_FF_FF;
-        //let spidr = (self.data()[0] as TIME) | (self.data()[1] as TIME) << 8;
-        //assert_eq!(spidr, spidr2 as usize);
-        spidr2 as usize
-
+        (self.data() & 0x00_00_00_00_00_00_FF_FF) as TIME
     }
 
     #[inline]
     fn ftoa(&self) -> TIME {
-        //let ftoa = (self.data()[2] & 15) as TIME;
-        //let val = packet_change(self.data())[0];
-        let ftoa2 = (self.data()[0] & 0x00_00_00_00_00_0F_00_00) >> 16;
-        //assert_eq!(ftoa, ftoa2 as usize);
-        ftoa2 as TIME
-
+        ((self.data() & 0x00_00_00_00_00_0F_00_00) >> 16) as TIME
     }
 
     #[inline]
     fn tot(&self) -> u16 {
-        //let tot = ((self.data()[2] & 240) as u16)>>4 | ((self.data()[3] & 63) as u16)<<4;
-        //let val = packet_change(self.data())[0];
-        let tot2 = (self.data()[0] & 0x00_00_00_00_3F_F0_00_00) >> 20;
-        //assert_eq!(tot, tot2 as u16);
-        tot2 as u16
-
+        ((self.data() & 0x00_00_00_00_3F_F0_00_00) >> 20) as u16
     }
 
     #[inline]
     fn toa(&self) -> TIME {
-        //let toa = ((self.data()[3] >> 6) as TIME) | (self.data()[4] as TIME)<<2 | ((self.data()[5] & 15) as TIME)<<10;
-        //let val = packet_change(self.data())[0];
-        let toa2 = (self.data()[0] & 0x00_00_0F_FF_C0_00_00_00) >> 30;
-        //assert_eq!(toa, toa2 as usize);
-        toa2 as TIME
+        ((self.data() & 0x00_00_0F_FF_C0_00_00_00) >> 30) as TIME
     }
 
     #[inline]
@@ -135,45 +95,27 @@ pub trait Packet {
     fn electron_time(&self) -> TIME {
         let spidr = self.spidr();
         let ctoa = self.ctoa();
-        //let ftoa2 = (!self.data()[2] & 15) as usize;
-        //let ctoa2 = (toa << 4) | ftoa2;
         spidr * 262_144 + ctoa
     }
 
     #[inline]
     fn tdc_coarse(&self) -> TIME {
-        //let tdc_coarse = ((self.data()[1] & 254) as TIME)>>1 | ((self.data()[2]) as TIME)<<7 | ((self.data()[3]) as TIME)<<15 | ((self.data()[4]) as TIME)<<23 | ((self.data()[5] & 15) as TIME)<<31;
-        //let val = packet_change(self.data())[0];
-        let tdc_coarse2 = (self.data()[0] & 0x00_00_0F_FF_FF_FF_FE_00) >> 9;
-        //assert_eq!(tdc_coarse, tdc_coarse2 as usize);
-        tdc_coarse2 as TIME
+        ((self.data() & 0x00_00_0F_FF_FF_FF_FE_00) >> 9) as TIME
     }
     
     #[inline]
     fn tdc_fine(&self) -> TIME {
-        //let tdc_fine = ((self.data()[0] & 224) as TIME >> 5) | ((self.data()[1] & 1) as TIME) << 3;
-        //let val = packet_change(self.data())[0];
-        let tdc_fine2 = (self.data()[0] & 0x00_00_00_00_00_00_01_E0) >> 5;
-        //assert_eq!(tdc_fine, tdc_fine2 as usize);
-        tdc_fine2 as TIME
+        ((self.data() & 0x00_00_00_00_00_00_01_E0) >> 5) as TIME
     }
 
     #[inline]
     fn tdc_counter(&self) -> u16 {
-        //let counter = ((self.data()[5] & 240) as u16) >> 4 | (self.data()[6] as u16) << 4;
-        //let val = packet_change(self.data())[0];
-        let counter2 = (self.data()[0] & 0x00_FF_F0_00_00_00_00_00) >> 44;
-        //assert_eq!(counter, counter2 as u16);
-        counter2 as u16
+        ((self.data() & 0x00_FF_F0_00_00_00_00_00) >> 44) as u16
     }
 
     #[inline]
     fn tdc_type(&self) -> u8 {
-        //let tdc_type = self.data()[7] & 15 ;
-        //let val = packet_change(self.data())[0];
-        let tdc_type2 = (self.data()[0] & 0x0F_00_00_00_00_00_00_00) >> 56;
-        //assert_eq!(tdc_type, tdc_type2 as u8);
-        tdc_type2 as u8
+        ((self.data() & 0x0F_00_00_00_00_00_00_00) >> 56) as u8
     }
 
     #[inline]
@@ -219,36 +161,36 @@ pub trait Packet {
     }
 }
 
-pub struct PacketEELS<'a> {
+pub struct PacketEELS {
     pub chip_index: u8,
-    pub data: &'a [u64],
+    pub data: u64,
 }
 
-impl<'a> Packet for PacketEELS<'a> {
+impl Packet for PacketEELS {
     fn ci(&self) -> u8 {
         self.chip_index
     }
-    fn data(&self) -> &[u64] {
+    fn data(&self) -> u64 {
         self.data
     }
 }
 
-impl<'a> PacketEELS<'a> {
+impl PacketEELS {
     pub const fn chip_array() -> (POSITION, POSITION) {
         (1025, 256)
     }
 }
 
-pub struct TimeCorrectedPacketEELS<'a> {
+pub struct TimeCorrectedPacketEELS {
     pub chip_index: u8,
-    pub data: &'a [u64],
+    pub data: u64,
 }
 
-impl<'a> Packet for TimeCorrectedPacketEELS<'a> {
+impl Packet for TimeCorrectedPacketEELS {
     fn ci(&self) -> u8 {
         self.chip_index
     }
-    fn data(&self) -> &[u64] {
+    fn data(&self) -> u64 {
         self.data
     }
     
@@ -270,24 +212,25 @@ impl<'a> Packet for TimeCorrectedPacketEELS<'a> {
     }
 }
 
-impl<'a> TimeCorrectedPacketEELS<'a> {
+impl TimeCorrectedPacketEELS {
     pub const fn chip_array() -> (POSITION, POSITION) {
         (1025, 256)
     }
 }
 
-pub struct PacketDiffraction<'a> {
+pub struct PacketDiffraction {
     pub chip_index: u8,
-    pub data: &'a [u64],
+    pub data: u64,
 }
 
-impl<'a> Packet for PacketDiffraction<'a> {
+impl Packet for PacketDiffraction {
     fn ci(&self) -> u8 {
         self.chip_index
     }
-    fn data(&self) -> &[u64] {
+    fn data(&self) -> u64 {
         self.data
     }
+    /*
     fn x(&self) -> POSITION {
         let temp = (((self.data[6] & 224)>>4 | (self.data[7] & 15)<<4) | (((self.data[5] & 112)>>4)>>2)) as POSITION;
         match self.chip_index {
@@ -309,9 +252,10 @@ impl<'a> Packet for PacketDiffraction<'a> {
             _ => panic!("More than four CI."),
         }
     }
+    */
 }
 
-impl<'a> PacketDiffraction<'a> {
+impl PacketDiffraction {
     pub const fn chip_array() -> (POSITION, POSITION) {
         (512, 512)
     }

--- a/tpx3/src/packetlib.rs
+++ b/tpx3/src/packetlib.rs
@@ -18,6 +18,7 @@ pub trait Packet {
     #[inline]
     fn x(&self) -> POSITION {
         let temp2 = (((self.data() & 0x0F_E0_00_00_00_00_00_00) >> 52) | ((self.data() & 0x00_00_40_00_00_00_00_00) >> 46)) as POSITION;
+        
         match self.ci() {
             0 => 255 - temp2,
             1 => 256 * 4 - 1 - temp2,

--- a/tpx3/src/packetlib.rs
+++ b/tpx3/src/packetlib.rs
@@ -14,6 +14,8 @@ pub fn packet_change(v: &[u8]) -> &[u64] {
 pub trait Packet {
     fn ci(&self) -> u8;
     fn data(&self) -> u64;
+
+    #[inline]
     fn x(&self) -> POSITION {
         let temp2 = (((self.data() & 0x0F_E0_00_00_00_00_00_00) >> 52) | ((self.data() & 0x00_00_40_00_00_00_00_00) >> 46)) as POSITION;
         match self.ci() {
@@ -25,10 +27,12 @@ pub trait Packet {
         }
     }
     
+    #[inline]
     fn x_raw(&self) -> POSITION {
         (((self.data() & 0x0F_E0_00_00_00_00_00_00) >> 52) | ((self.data() & 0x00_00_40_00_00_00_00_00) >> 46)) as POSITION
     }
     
+    #[inline]
     fn y(&self) -> POSITION {
         (((self.data() & 0x00_1F_80_00_00_00_00_00) >> 45) | ((self.data() & 0x00_00_30_00_00_00_00_00) >> 44)) as POSITION
     }
@@ -268,7 +272,6 @@ pub struct InversePacket {
     pub id: usize,
 }
 
-use std::convert::TryInto;
 use crate::tdclib::TdcType;
 
 impl InversePacket {

--- a/tpx3/src/postlib.rs
+++ b/tpx3/src/postlib.rs
@@ -2,7 +2,7 @@ pub mod coincidence {
 
     use std::fs::OpenOptions;
     use crate::spimlib::SPIM_PIXELS;
-    use crate::packetlib::{Packet, TimeCorrectedPacketEELS as Pack};
+    use crate::packetlib::{Packet, TimeCorrectedPacketEELS as Pack, packet_change};
     use crate::tdclib::{TdcControl, TdcType, PeriodicTdcRef, NonPeriodicTdcRef};
     use crate::postlib::isi_box;
     use std::io;
@@ -379,7 +379,7 @@ pub mod coincidence {
                 match *pack_oct {
                     [84, 80, 88, 51, nci, _, _, _] => {ci=nci;},
                     _ => {
-                        let packet = Pack { chip_index: ci, data: pack_oct.try_into().unwrap() };
+                        let packet = Pack { chip_index: ci, data: packet_change(pack_oct)};
                         match packet.id() {
                             6 if packet.tdc_type() == np_tdc.id() => {
                                 temp_tdc.add_tdc(&packet, 0);
@@ -448,7 +448,7 @@ pub mod coincidence {
                 match *pack_oct {
                     [84, 80, 88, 51, nci, _, _, _] => {ci=nci;},
                     _ => {
-                        let packet = Pack { chip_index: ci, data: pack_oct.try_into().unwrap() };
+                        let packet = Pack { chip_index: ci, data: packet_change(pack_oct) };
                         match packet.id() {
                             6 if packet.tdc_type() == spim_tdc.id() => {
                                 tp3_tdc_counter += 1;
@@ -526,7 +526,7 @@ pub mod coincidence {
                 match *pack_oct {
                     [84, 80, 88, 51, nci, _, _, _] => {ci=nci;},
                     _ => {
-                        let packet = Pack { chip_index: ci, data: pack_oct.try_into().unwrap() };
+                        let packet = Pack { chip_index: ci, data: packet_change(pack_oct) };
                         match packet.id() {
                             6 if packet.tdc_type() == spim_tdc.id() => {
                                 coinc_data.add_spim_line(&packet);
@@ -820,7 +820,7 @@ pub mod isi_box {
 
 pub mod ntime_resolved {
     use std::fs::OpenOptions;
-    use crate::packetlib::{Packet, PacketEELS as Pack};
+    use crate::packetlib::{Packet, PacketEELS as Pack, packet_change};
     use crate::tdclib::{TdcControl, TdcType, PeriodicTdcRef};
     use std::io::prelude::*;
     use crate::clusterlib::cluster::{SingleElectron, CollectionElectron};
@@ -950,7 +950,7 @@ pub mod ntime_resolved {
                 match pack_oct {
                     &[84, 80, 88, 51, nci, _, _, _] => {ci = nci},
                     _ => {
-                        let packet = Pack{chip_index: ci, data: pack_oct.try_into().unwrap()};
+                        let packet = Pack{chip_index: ci, data: packet_change(pack_oct)};
                         match packet.id() {
                             6 if packet.tdc_type() == data.spim_tdc_type.associate_value() => {
                                 data.add_spim_tdc(&packet);

--- a/tpx3/src/postlib.rs
+++ b/tpx3/src/postlib.rs
@@ -701,8 +701,8 @@ pub mod isi_box {
                 collect::<Vec<_>>();
 
             for val in iter3 {
-                self.data.0.insert(val.1.0, (val.1.1.0 - self.line_time.unwrap() as u64, val.1.1.1, val.1.1.2, val.1.1.3, val.1.1.4));
-                println!("{:?} and {:?}", val.0, val.1);
+                println!("{:?} and {:?} and {:?}", val.0, val.1, self.data.0[val.1.0+2]);
+                self.data.0.insert(val.1.0+1, (val.1.1.0 - self.line_time.unwrap() as u64, val.1.1.1, val.1.1.2, val.1.1.3, val.1.1.4));
             }
 
             println!("{:?}", self.line_time.unwrap());

--- a/tpx3/src/postlib.rs
+++ b/tpx3/src/postlib.rs
@@ -293,7 +293,7 @@ pub mod coincidence {
             self.tdc.iter_mut().zip(val.0.iter_mut()).
                 filter(|((_time, _channel, _dt), corr)| corr.is_some()).
                 for_each(|((time, _channel, _dt), corr)| {
-                *time += corr.unwrap() as usize;
+                *time += corr.unwrap();
                 //*time = *time - (*time / (Pack::electron_overflow() * 6)) * (Pack::electron_overflow() * 6);
                 *corr = Some(0);
             });
@@ -379,7 +379,7 @@ pub mod coincidence {
                 match *pack_oct {
                     [84, 80, 88, 51, nci, _, _, _] => {ci=nci;},
                     _ => {
-                        let packet = Pack { chip_index: ci, data: packet_change(pack_oct)};
+                        let packet = Pack { chip_index: ci, data: packet_change(pack_oct)[0] };
                         match packet.id() {
                             6 if packet.tdc_type() == np_tdc.id() => {
                                 temp_tdc.add_tdc(&packet, 0);
@@ -448,7 +448,7 @@ pub mod coincidence {
                 match *pack_oct {
                     [84, 80, 88, 51, nci, _, _, _] => {ci=nci;},
                     _ => {
-                        let packet = Pack { chip_index: ci, data: packet_change(pack_oct) };
+                        let packet = Pack { chip_index: ci, data: packet_change(pack_oct)[0] };
                         match packet.id() {
                             6 if packet.tdc_type() == spim_tdc.id() => {
                                 tp3_tdc_counter += 1;
@@ -526,7 +526,7 @@ pub mod coincidence {
                 match *pack_oct {
                     [84, 80, 88, 51, nci, _, _, _] => {ci=nci;},
                     _ => {
-                        let packet = Pack { chip_index: ci, data: packet_change(pack_oct) };
+                        let packet = Pack { chip_index: ci, data: packet_change(pack_oct)[0] };
                         match packet.id() {
                             6 if packet.tdc_type() == spim_tdc.id() => {
                                 coinc_data.add_spim_line(&packet);
@@ -950,7 +950,7 @@ pub mod ntime_resolved {
                 match pack_oct {
                     &[84, 80, 88, 51, nci, _, _, _] => {ci = nci},
                     _ => {
-                        let packet = Pack{chip_index: ci, data: packet_change(pack_oct)};
+                        let packet = Pack{chip_index: ci, data: packet_change(pack_oct)[0]};
                         match packet.id() {
                             6 if packet.tdc_type() == data.spim_tdc_type.associate_value() => {
                                 data.add_spim_tdc(&packet);

--- a/tpx3/src/postlib.rs
+++ b/tpx3/src/postlib.rs
@@ -932,12 +932,13 @@ pub mod isi_box {
                     assert_eq!(ph21.1, ph22.1);
                 });
 
-            println!("***IsiBox***: Size of the (first/second) channel: ({} / {}). Number of coincidences: {}", vec1_len, vec2.len(), corr);
             
             let dt_vec = new_list.0.iter().
                 filter(|(_time, _channel, spim_index, spim_frame)| spim_index.is_some() && spim_frame.is_some()).
                 map(|(dtime, _channel, _spim_index, _spim_frame)| *dtime).
                 collect::<Vec<i64>>();
+            
+            println!("***IsiBox***: Size of the (first/second) channel: ({} / {}). Number of coincidences: {}. Number of output coincidences: {}.", vec1_len, vec2.len(), corr, dt_vec.len());
             
             let spim_index_vec = new_list.0.iter().
                 filter(|(_time, _channel, spim_index, spim_frame)| spim_index.is_some() && spim_frame.is_some()).

--- a/tpx3/src/postlib.rs
+++ b/tpx3/src/postlib.rs
@@ -422,6 +422,7 @@ pub mod coincidence {
         let tdc_vec = temp_tdc.get_sync();
         let _isi_tdc_counter = tdc_vec.len();
         let mut tdc_iter = tdc_vec.iter();
+
         
         
         let bar = ProgressBar::new(progress_size);
@@ -854,16 +855,17 @@ pub mod isi_box {
     */
         
         pub fn get_timelist_with_tp3_tick(&self) -> Vec<(TIME, COUNTER, Option<i64>)> {
-            let first = self.data.0.iter().
+            let first = self.data_raw.0.iter().
                 filter(|(_time, channel, _spim_index, _spim_frame, _dt)| *channel == 16).
                 map(|(time, _channel, _spim_index, _spim_frame, _dt)| (*time * 1200 * 6) / 15625).
                 next().
                 unwrap();
-
-            self.data.0.iter().
+            
+            self.data_raw.0.iter().
                 map(|(time, channel, _spim_index, _spim_frame, dt)| (((*time * 1200 * 6) / 15625) - first, *channel, *dt)).
                 //map(|(time, channel)| (time - (time / 103_079_215_104) * 103_079_215_104, channel)).
                 collect::<Vec<_>>()
+            
         }
 
         fn output_spim(&self) {

--- a/tpx3/src/postlib.rs
+++ b/tpx3/src/postlib.rs
@@ -11,9 +11,7 @@ pub mod coincidence {
     use std::time::Instant;
     use crate::clusterlib::cluster::{SingleElectron, CollectionElectron};
     use crate::auxiliar::ConfigAcquisition;
-    use std::convert::TryInto;
     use crate::auxiliar::value_types::*;
-    use rayon::prelude::*;
     use indicatif::{ProgressBar, ProgressStyle};
 
     const ISI_BUFFER_SIZE: usize = 512_000_000; //Buffer size reading files when using TP3 and IsiBox

--- a/tpx3/src/postlib.rs
+++ b/tpx3/src/postlib.rs
@@ -415,6 +415,7 @@ pub mod coincidence {
         //IsiBox loading file & setting up synchronization
         let f = fs::File::open(file2).unwrap();
         let temp_list = isi_box::get_channel_timelist(f, coinc_data.spim_size, spim_tdc.pixel_time(coinc_data.spim_size.0 * 15_625 / 10_000));
+        println!("***IsiBox***: Selected pixel time is (ns): {}.", spim_tdc.pixel_time(coinc_data.spim_size.0 * 15625 / 10000));
         let _begin_isi_time = temp_list.start_time;
         let mut temp_tdc = TempTdcData::new_from_isilist(temp_list);
         let tdc_vec = temp_tdc.get_sync();

--- a/tpx3/src/postlib.rs
+++ b/tpx3/src/postlib.rs
@@ -414,8 +414,8 @@ pub mod coincidence {
     
         //IsiBox loading file & setting up synchronization
         let f = fs::File::open(file2).unwrap();
-        let temp_list = isi_box::get_channel_timelist(f, coinc_data.spim_size, spim_tdc.pixel_time(coinc_data.spim_size.0 * 15_625 / 10_000));
-        println!("***IsiBox***: Selected pixel time is (ns): {}.", spim_tdc.pixel_time(coinc_data.spim_size.0 * 15625 / 10000));
+        let temp_list = isi_box::get_channel_timelist(f, coinc_data.spim_size, spim_tdc.pixel_time(coinc_data.spim_size.0) * 15_625 / 10_000);
+        println!("***IsiBox***: Selected pixel time is (ns): {}.", spim_tdc.pixel_time(coinc_data.spim_size.0) * 15_625 / 10_000);
         let _begin_isi_time = temp_list.start_time;
         let mut temp_tdc = TempTdcData::new_from_isilist(temp_list);
         let tdc_vec = temp_tdc.get_sync();

--- a/tpx3/src/postlib.rs
+++ b/tpx3/src/postlib.rs
@@ -929,7 +929,7 @@ pub mod isi_box {
             println!("***IsiBox***: Size of the (first/second) channel: ({} / {}). Number of coincidences: {}", vec1_len, vec2.len(), corr);
             
             let dt_vec = new_list.0.iter().
-                filter(|(_time, _channel, spim_index, spim_frame)| spim_index.is_some() && spim_frame.is_some()).
+                //filter(|(_time, _channel, spim_index, spim_frame)| spim_index.is_some() && spim_frame.is_some()).
                 map(|(dtime, _channel, _spim_index, _spim_frame)| *dtime).
                 collect::<Vec<i64>>();
 
@@ -979,8 +979,8 @@ pub mod isi_box {
             }
             list.determine_line_time();
             list.check_for_issues();
-            panic!("bye");
-            list.output_spim();
+            list.correct_data();
+            //list.output_spim();
             list.search_coincidence(2, 12);
             list
         }

--- a/tpx3/src/speclib.rs
+++ b/tpx3/src/speclib.rs
@@ -8,7 +8,6 @@ use crate::isi_box_new;
 use crate::errorlib::Tp3ErrorKind;
 use std::time::Instant;
 use std::io::Write;
-use std::convert::TryInto;
 //use rayon::prelude::*;
 use core::ops::{Add, AddAssign};
 use crate::auxiliar::value_types::*;
@@ -18,7 +17,6 @@ const BUFFER_SIZE: usize = 16384 * 2;
 //const SR_TIME: usize = 10_000; //Time window (10_000 -> 10 us);
 //const SR_INDEX: usize = 64; //Maximum x index value to account in the average calculation;
 //const SR_MIN: usize = 0; //Minimum array size to perform the average in super resolution;
-const TILT_FRACTION: usize = 16; //Values with y = 256 will be tilted by 256 / 16;
 
 fn as_bytes<T>(v: &[T]) -> &[u8] {
     unsafe {

--- a/tpx3/src/speclib.rs
+++ b/tpx3/src/speclib.rs
@@ -36,6 +36,16 @@ fn as_mut_bytes<T>(v: &[T]) -> &mut [u8] {
     }
 }
 
+fn packet_change(v: &[u8]) -> &[u64] {
+    unsafe {
+        std::slice::from_raw_parts(
+            v.as_ptr() as *const u64,
+            //v.len() )
+            v.len() * std::mem::size_of::<u8>() / std::mem::size_of::<u64>())
+    }
+}
+
+
 macro_rules! genbitdepth {
     ($($x: ty),*) => {
         $(
@@ -609,7 +619,7 @@ fn build_data<T: TdcControl, W: SpecKind>(data: &[u8], final_data: &mut W, last_
         match *x {
             [84, 80, 88, 51, nci, _, _, _] => *last_ci = nci,
             _ => {
-                let packet = Pack { chip_index: *last_ci, data: x.try_into().unwrap()};
+                let packet = Pack { chip_index: *last_ci, data: x};
                 
                 match packet.id() {
                     11 => {

--- a/tpx3/src/speclib.rs
+++ b/tpx3/src/speclib.rs
@@ -609,7 +609,7 @@ fn build_data<T: TdcControl, W: SpecKind>(data: &[u8], final_data: &mut W, last_
         match *x {
             [84, 80, 88, 51, nci, _, _, _] => *last_ci = nci,
             _ => {
-                let packet = Pack { chip_index: *last_ci, data: packet_change(x)};
+                let packet = Pack { chip_index: *last_ci, data: packet_change(x)[0]};
                 
                 match packet.id() {
                     11 => {

--- a/tpx3/src/spimlib.rs
+++ b/tpx3/src/spimlib.rs
@@ -1,6 +1,6 @@
 //!`spimlib` is a collection of tools to set hyperspectral EELS acquisition.
 
-use crate::packetlib::{Packet, PacketEELS};
+use crate::packetlib::{Packet, PacketEELS, packet_change};
 use crate::auxiliar::{Settings, misc::TimepixRead};
 use crate::tdclib::{TdcControl, PeriodicTdcRef, isi_box, isi_box::{IsiBoxTools, IsiBoxHand}};
 use crate::errorlib::Tp3ErrorKind;
@@ -272,7 +272,7 @@ fn build_spim_data<T: TdcControl, W: SpimKind>(list: &mut W, data: &[u8], last_c
         match *x {
             [84, 80, 88, 51, nci, _, _, _] => *last_ci = nci,
             _ => {
-                let packet = PacketEELS { chip_index: *last_ci, data: x.try_into().unwrap()};
+                let packet = PacketEELS { chip_index: *last_ci, data: packet_change(x)};
                 let id = packet.id();
                 match id {
                     11 => {

--- a/tpx3/src/spimlib.rs
+++ b/tpx3/src/spimlib.rs
@@ -272,7 +272,7 @@ fn build_spim_data<T: TdcControl, W: SpimKind>(list: &mut W, data: &[u8], last_c
         match *x {
             [84, 80, 88, 51, nci, _, _, _] => *last_ci = nci,
             _ => {
-                let packet = PacketEELS { chip_index: *last_ci, data: packet_change(x)};
+                let packet = PacketEELS { chip_index: *last_ci, data: packet_change(x)[0]};
                 let id = packet.id();
                 match id {
                     11 => {

--- a/tpx3/src/spimlib.rs
+++ b/tpx3/src/spimlib.rs
@@ -6,7 +6,7 @@ use crate::tdclib::{TdcControl, PeriodicTdcRef, isi_box, isi_box::{IsiBoxTools, 
 use crate::errorlib::Tp3ErrorKind;
 use std::time::Instant;
 use crate::isi_box_new;
-use std::io::{Write};
+use std::io::Write;
 use std::sync::mpsc;
 use std::thread;
 use std::convert::TryInto;

--- a/tpx3/src/tdclib.rs
+++ b/tpx3/src/tdclib.rs
@@ -6,7 +6,6 @@ mod tdcvec {
     use crate::errorlib::Tp3ErrorKind;
     use crate::tdclib::TdcType;
     use crate::packetlib::{Packet, PacketEELS as Pack, packet_change};
-    use std::convert::TryInto;
     use crate::auxiliar::value_types::*;
 
     pub struct TdcSearch<'a> {
@@ -327,7 +326,7 @@ impl TdcControl for PeriodicTdcRef {
             counter_offset,
             last_hard_counter: 0,
             counter_overflow: 0,
-            begin_time: begin_time,
+            begin_time,
             begin_frame: begin_time,
             ticks_to_frame,
             period,
@@ -477,8 +476,8 @@ pub mod isi_box {
     use std::net::TcpStream;
     use std::io::{Read, Write};
     use std::sync::{Arc, Mutex};
-    use std::{thread};
-    use crate::spimlib::{SPIM_PIXELS, VIDEO_TIME};
+    use std::thread;
+    use crate::spimlib::SPIM_PIXELS;
 
     pub const CHANNELS: usize = 17;
     

--- a/tpx3/src/tdclib.rs
+++ b/tpx3/src/tdclib.rs
@@ -5,7 +5,7 @@
 mod tdcvec {
     use crate::errorlib::Tp3ErrorKind;
     use crate::tdclib::TdcType;
-    use crate::packetlib::{Packet, PacketEELS as Pack};
+    use crate::packetlib::{Packet, PacketEELS as Pack, packet_change};
     use std::convert::TryInto;
     use crate::auxiliar::value_types::*;
 
@@ -158,7 +158,7 @@ mod tdcvec {
                 match *x {
                     [84, 80, 88, 51, _, _, _, _] => {},
                     _ => {
-                        let packet = Pack {chip_index: 0, data: x.try_into().unwrap()};
+                        let packet = Pack {chip_index: 0, data: packet_change(x)};
                         if packet.id() == 6 && self.tdc_choosen.is_same_inputline(packet.tdc_type()) {
                             self.add_tdc(&packet);
                         }

--- a/tpx3/src/tdclib.rs
+++ b/tpx3/src/tdclib.rs
@@ -158,7 +158,7 @@ mod tdcvec {
                 match *x {
                     [84, 80, 88, 51, _, _, _, _] => {},
                     _ => {
-                        let packet = Pack {chip_index: 0, data: packet_change(x)};
+                        let packet = Pack {chip_index: 0, data: packet_change(x)[0]};
                         if packet.id() == 6 && self.tdc_choosen.is_same_inputline(packet.tdc_type()) {
                             self.add_tdc(&packet);
                         }


### PR DESCRIPTION
i) basically an unsafe &[u8] -> &[u64] ;
ii) postlib for isibox improved;
iii) Cargo.toml using panic="abort", which sped up 10% our spec acquisition