### PR TITLE
Speclib types

### DIFF
--- a/tpx3/src/bin/debug.rs
+++ b/tpx3/src/bin/debug.rs
@@ -16,13 +16,13 @@ fn connect_and_loop() -> Result<u8, Tp3ErrorKind> {
         0 if my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
             let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoFallingEdge, &mut pack, None)?;
-            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Live1D)?;
+            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Live1D)?;
             Ok(my_settings.mode)
         },
         0 if !my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
             let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoFallingEdge, &mut pack, None)?;
-            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Live2D)?;
+            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Live2D)?;
             Ok(my_settings.mode)
         },
         1 => {

--- a/tpx3/src/bin/debug.rs
+++ b/tpx3/src/bin/debug.rs
@@ -15,13 +15,11 @@ fn connect_and_loop() -> Result<u8, Tp3ErrorKind> {
     match my_settings.mode {
         0 if my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            //let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoFallingEdge, &mut pack, None)?;
             speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::Live1D)?;
             Ok(my_settings.mode)
         },
         0 if !my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            //let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoFallingEdge, &mut pack, None)?;
             speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::Live2D)?;
             Ok(my_settings.mode)
         },

--- a/tpx3/src/bin/debug.rs
+++ b/tpx3/src/bin/debug.rs
@@ -15,14 +15,14 @@ fn connect_and_loop() -> Result<u8, Tp3ErrorKind> {
     match my_settings.mode {
         0 if my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoFallingEdge, &mut pack, None)?;
-            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Live1D)?;
+            //let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoFallingEdge, &mut pack, None)?;
+            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::Live1D)?;
             Ok(my_settings.mode)
         },
         0 if !my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoFallingEdge, &mut pack, None)?;
-            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Live2D)?;
+            //let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoFallingEdge, &mut pack, None)?;
+            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::Live2D)?;
             Ok(my_settings.mode)
         },
         1 => {

--- a/tpx3/src/bin/isibox_main.rs
+++ b/tpx3/src/bin/isibox_main.rs
@@ -23,7 +23,7 @@ fn connect_and_loop() -> Result<u8, Tp3ErrorKind> {
         0 if !my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
             let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
-            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Live2D)?;
+            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Live2D)?;
             Ok(my_settings.mode)
         },
         2 => {

--- a/tpx3/src/bin/isibox_main.rs
+++ b/tpx3/src/bin/isibox_main.rs
@@ -22,7 +22,6 @@ fn connect_and_loop() -> Result<u8, Tp3ErrorKind> {
         },
         0 if !my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            //let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
             speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::Live2D)?;
             Ok(my_settings.mode)
         },

--- a/tpx3/src/bin/isibox_main.rs
+++ b/tpx3/src/bin/isibox_main.rs
@@ -22,8 +22,8 @@ fn connect_and_loop() -> Result<u8, Tp3ErrorKind> {
         },
         0 if !my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
-            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Live2D)?;
+            //let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
+            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::Live2D)?;
             Ok(my_settings.mode)
         },
         2 => {

--- a/tpx3/src/clusterlib.rs
+++ b/tpx3/src/clusterlib.rs
@@ -12,7 +12,7 @@ pub mod cluster {
     
     const CLUSTER_DET: TIME = 128; //Cluster time window (in 640 Mhz or 1.5625).
     const CLUSTER_SPATIAL: isize = 2; // If electron hit position in both X or Y > CLUSTER_SPATIAL, then we have a new cluster.
-    static TIME_SHIFT: &[u8; 1024 * 256 * 401 * 2] = include_bytes!("time_shift_8.dat");
+    //static TIME_SHIFT: &[u8; 1024 * 256 * 401 * 2] = include_bytes!("time_shift_8.dat");
     
     /*
     fn as_bytes<T>(v: &[T]) -> &[u8] {
@@ -301,7 +301,8 @@ pub mod cluster {
             (self.data.0*6) as i64 - reference_time as i64
         }
         pub fn corrected_relative_time_from_abs_tdc(&self, reference_time: TIME) -> i64 {
-            self.relative_time_from_abs_tdc(reference_time) - transform_time_shift(TIME_SHIFT)[401 * (self.x() as usize + 1024 * self.y() as usize) + self.tot() as usize] as i64
+            //self.relative_time_from_abs_tdc(reference_time) - transform_time_shift(TIME_SHIFT)[401 * (self.x() as usize + 1024 * self.y() as usize) + self.tot() as usize] as i64
+            (self.data.0*6) as i64 - reference_time as i64
             //self.relative_time_from_abs_tdc(reference_time) - transform_time_shift(TIME_SHIFT)[self.x() as usize + 1024 * self.y() as usize] as i64 - transform_time_shift(TOT_TIME_SHIFT)[self.tot() as usize] as i64
         }
         pub fn spim_slice(&self) -> COUNTER {

--- a/tpx3/src/main.rs
+++ b/tpx3/src/main.rs
@@ -11,25 +11,21 @@ fn connect_and_loop() -> Result<u8, Tp3ErrorKind> {
     match my_settings.mode {
         0 if my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            //let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
             speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::Live1D)?;
             Ok(my_settings.mode)
         },
         0 if !my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            //let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
             speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::Live2D)?;
             Ok(my_settings.mode)
         },
         1 if my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            //let laser_tdc = SingleTriggerPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
             speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::LiveTR1D)?;
             Ok(my_settings.mode)
         },
         1 if !my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            //let laser_tdc = SingleTriggerPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
             speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::LiveTR2D)?;
             Ok(my_settings.mode)
         },
@@ -42,13 +38,11 @@ fn connect_and_loop() -> Result<u8, Tp3ErrorKind> {
         },
         6 => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            //let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
             speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::FastChrono)?;
             Ok(my_settings.mode)
         },
         7 => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            //let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
             speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::Chrono)?;
             Ok(my_settings.mode)
         },

--- a/tpx3/src/main.rs
+++ b/tpx3/src/main.rs
@@ -17,39 +17,39 @@ fn connect_and_loop() -> Result<u8, Tp3ErrorKind> {
         },
         0 if !my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
-            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Live2D)?;
+            //let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
+            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::Live2D)?;
             Ok(my_settings.mode)
         },
         1 if my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            let laser_tdc = SingleTriggerPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
-            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, laser_tdc, speclib::LiveTR1D)?;
+            //let laser_tdc = SingleTriggerPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
+            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::LiveTR1D)?;
             Ok(my_settings.mode)
         },
         1 if !my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            let laser_tdc = SingleTriggerPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
-            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, laser_tdc, speclib::LiveTR2D)?;
+            //let laser_tdc = SingleTriggerPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
+            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::LiveTR2D)?;
             Ok(my_settings.mode)
         },
         2 => {
             let spim_tdc = PeriodicTdcRef::new(TdcType::TdcOneFallingEdge, &mut pack, Some(my_settings.yspim_size))?;
             let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
             let measurement = spimlib::Live::new();
-            //spimlib::build_spim(pack, ns, my_settings, spim_tdc, np_tdc, measurement)?;
+            spimlib::build_spim(pack, ns, my_settings, spim_tdc, np_tdc, measurement)?;
             Ok(my_settings.mode)
         },
         6 => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
-            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::FastChrono)?;
+            //let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
+            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::FastChrono)?;
             Ok(my_settings.mode)
         },
         7 => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
-            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Chrono)?;
+            //let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
+            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::Chrono)?;
             Ok(my_settings.mode)
         },
         _ => Err(Tp3ErrorKind::MiscModeNotImplemented(my_settings.mode)),

--- a/tpx3/src/main.rs
+++ b/tpx3/src/main.rs
@@ -11,45 +11,45 @@ fn connect_and_loop() -> Result<u8, Tp3ErrorKind> {
     match my_settings.mode {
         0 if my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
-            let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
-            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Live1D)?;
+            //let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
+            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, speclib::Live1D)?;
             Ok(my_settings.mode)
         },
         0 if !my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
             let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
-            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Live2D)?;
+            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Live2D)?;
             Ok(my_settings.mode)
         },
         1 if my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
             let laser_tdc = SingleTriggerPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
-            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, laser_tdc, speclib::LiveTR1D)?;
+            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, laser_tdc, speclib::LiveTR1D)?;
             Ok(my_settings.mode)
         },
         1 if !my_settings.bin => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
             let laser_tdc = SingleTriggerPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
-            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, laser_tdc, speclib::LiveTR2D)?;
+            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, laser_tdc, speclib::LiveTR2D)?;
             Ok(my_settings.mode)
         },
         2 => {
             let spim_tdc = PeriodicTdcRef::new(TdcType::TdcOneFallingEdge, &mut pack, Some(my_settings.yspim_size))?;
             let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
             let measurement = spimlib::Live::new();
-            spimlib::build_spim(pack, ns, my_settings, spim_tdc, np_tdc, measurement)?;
+            //spimlib::build_spim(pack, ns, my_settings, spim_tdc, np_tdc, measurement)?;
             Ok(my_settings.mode)
         },
         6 => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
             let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
-            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::FastChrono)?;
+            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::FastChrono)?;
             Ok(my_settings.mode)
         },
         7 => {
             let frame_tdc = PeriodicTdcRef::new(TdcType::TdcOneRisingEdge, &mut pack, None)?;
             let np_tdc = NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, &mut pack, None)?;
-            speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Chrono)?;
+            //speclib::run_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, speclib::Chrono)?;
             Ok(my_settings.mode)
         },
         _ => Err(Tp3ErrorKind::MiscModeNotImplemented(my_settings.mode)),

--- a/tpx3/src/speclib.rs
+++ b/tpx3/src/speclib.rs
@@ -559,18 +559,18 @@ pub fn run_spectrum<V, U, Y>(mut pack: V, ns: U, my_settings: Settings, frame_td
     match my_settings.bytedepth {
         1 => {
             let measurement = kind.gen8(&my_settings);
-            let tdc = measurement.build_aux_tdc(&mut pack);
-            build_spectrum(pack, ns, my_settings, frame_tdc, tdc, measurement)?;
+            let aux_tdc = measurement.build_aux_tdc(&mut pack);
+            build_spectrum(pack, ns, my_settings, frame_tdc, aux_tdc, measurement)?;
         },
         2 => {
             let measurement = kind.gen16(&my_settings);
-            let tdc = measurement.build_aux_tdc(&mut pack);
-            build_spectrum(pack, ns, my_settings, frame_tdc, tdc, measurement)?;
+            let aux_tdc = measurement.build_aux_tdc(&mut pack);
+            build_spectrum(pack, ns, my_settings, frame_tdc, aux_tdc, measurement)?;
         },
         4 => {
             let measurement = kind.gen32(&my_settings);
-            let tdc = measurement.build_aux_tdc(&mut pack);
-            build_spectrum(pack, ns, my_settings, frame_tdc, tdc, measurement)?;
+            let aux_tdc = measurement.build_aux_tdc(&mut pack);
+            build_spectrum(pack, ns, my_settings, frame_tdc, aux_tdc, measurement)?;
         },
         _ => {return Err(Tp3ErrorKind::SetByteDepth)},
     }

--- a/tpx3/src/speclib.rs
+++ b/tpx3/src/speclib.rs
@@ -194,7 +194,7 @@ impl<L: BitDepth> SpecKind for SpecMeasurement<Live1D, L> {
         SpecMeasurement{ data: tp3_vec!(1), aux_data: Vec::new(), is_ready: false, global_stop: false, _kind: Live1D}
     }
     fn build_aux_tdc<V: TimepixRead>(&self, pack: &mut V) -> Self::SupplementaryTdc {
-        NonPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, pack, None).unwrap()
+        Self::SupplementaryTdc::new(TdcType::TdcTwoRisingEdge, pack, None).unwrap()
     }
     #[inline]
     fn add_electron_hit(&mut self, pack: &Pack, _settings: &Settings, _frame_tdc: &PeriodicTdcRef, _ref_tdc: &Self::SupplementaryTdc) {
@@ -233,7 +233,7 @@ impl<L: BitDepth> SpecKind for SpecMeasurement<LiveTR2D, L> {
         SpecMeasurement{ data: tp3_vec!(2), aux_data: Vec::new(), is_ready: false, global_stop: false, _kind: LiveTR2D}
     }
     fn build_aux_tdc<V: TimepixRead>(&self, pack: &mut V) -> Self::SupplementaryTdc {
-        SingleTriggerPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, pack, None).unwrap()
+        Self::SupplementaryTdc::new(TdcType::TdcTwoRisingEdge, pack, None).unwrap()
     }
     #[inline]
     fn add_electron_hit(&mut self, pack: &Pack, settings: &Settings, _frame_tdc: &PeriodicTdcRef, ref_tdc: &Self::SupplementaryTdc) {
@@ -273,7 +273,7 @@ impl<L: BitDepth> SpecKind for SpecMeasurement<LiveTR1D, L> {
         SpecMeasurement{ data: tp3_vec!(1), aux_data: Vec::new(), is_ready: false, global_stop: false, _kind: LiveTR1D}
     }
     fn build_aux_tdc<V: TimepixRead>(&self, pack: &mut V) -> Self::SupplementaryTdc {
-        SingleTriggerPeriodicTdcRef::new(TdcType::TdcTwoRisingEdge, pack, None).unwrap()
+        Self::SupplementaryTdc::new(TdcType::TdcTwoRisingEdge, pack, None).unwrap()
     }
     #[inline]
     fn add_electron_hit(&mut self, pack: &Pack, settings: &Settings, _frame_tdc: &PeriodicTdcRef, ref_tdc: &Self::SupplementaryTdc) {
@@ -298,7 +298,7 @@ impl<L: BitDepth> SpecKind for SpecMeasurement<LiveTR1D, L> {
     }
 }
 
-/*
+
 impl<L: BitDepth> SpecKind for SpecMeasurement<LiveTilted2D, L> {
     type SupplementaryTdc = NonPeriodicTdcRef;
     fn is_ready(&self) -> bool {
@@ -313,8 +313,8 @@ impl<L: BitDepth> SpecKind for SpecMeasurement<LiveTilted2D, L> {
     fn new(_settings: &Settings) -> Self {
         SpecMeasurement{ data: tp3_vec!(2), aux_data: Vec::new(), is_ready: false, global_stop: false, _kind: LiveTilted2D }
     }
-    fn new(_settings: &Settings) -> Self {
-        SpecMeasurement{ data: tp3_vec!(2), aux_data: Vec::new(), is_ready: false, global_stop: false, _kind: LiveTilted2D }
+    fn build_aux_tdc<V: TimepixRead>(&self, pack: &mut V) -> Self::SupplementaryTdc {
+        Self::SupplementaryTdc::new(TdcType::TdcTwoRisingEdge, pack, None).unwrap()
     }
     #[inline]
     fn add_electron_hit(&mut self, pack: &Pack, _settings: &Settings, _frame_tdc: &PeriodicTdcRef, _ref_tdc: &Self::SupplementaryTdc) {
@@ -359,12 +359,8 @@ impl<L: BitDepth> SpecKind for SpecMeasurement<FastChrono, L> {
         temp_vec[len] = L::ten();
         SpecMeasurement{ data: temp_vec, aux_data: Vec::new(), is_ready: false, global_stop: false, _kind: FastChrono}
     }
-    fn new(settings: &Settings) -> Self {
-        let len = (settings.xspim_size*CAM_DESIGN.0) as usize;
-        let mut temp_vec = vec![L::zero(); len + 1];
-    //type MeasKind;
-        temp_vec[len] = L::ten();
-        SpecMeasurement{ data: temp_vec, aux_data: Vec::new(), is_ready: false, global_stop: false, _kind: FastChrono}
+    fn build_aux_tdc<V: TimepixRead>(&self, pack: &mut V) -> Self::SupplementaryTdc {
+        Self::SupplementaryTdc::new(TdcType::TdcTwoRisingEdge, pack, None).unwrap()
     }
     #[inline]
     fn add_electron_hit(&mut self, pack: &Pack, settings: &Settings, frame_tdc: &PeriodicTdcRef, _ref_tdc: &Self::SupplementaryTdc) {
@@ -404,11 +400,8 @@ impl<L: BitDepth> SpecKind for SpecMeasurement<Chrono, L> {
         temp_vec[len] = L::ten();
         SpecMeasurement{ data: temp_vec, aux_data: Vec::new(), is_ready: false, global_stop: false, _kind: Chrono}
     }
-    fn new(settings: &Settings) -> Self {
-        let len = (settings.xspim_size*CAM_DESIGN.0) as usize;
-        let mut temp_vec = vec![L::zero(); len + 1];
-        temp_vec[len] = L::ten();
-        SpecMeasurement{ data: temp_vec, aux_data: Vec::new(), is_ready: false, global_stop: false, _kind: Chrono}
+    fn build_aux_tdc<V: TimepixRead>(&self, pack: &mut V) -> Self::SupplementaryTdc {
+        Self::SupplementaryTdc::new(TdcType::TdcTwoRisingEdge, pack, None).unwrap()
     }
     #[inline]
     fn add_electron_hit(&mut self, pack: &Pack, settings: &Settings, frame_tdc: &PeriodicTdcRef, _ref_tdc: &Self::SupplementaryTdc) {
@@ -437,7 +430,7 @@ impl<L: BitDepth> SpecKind for SpecMeasurement<Chrono, L> {
         }
     }
 }
-*/
+
 
 /*
 impl<L: BitDepth> SpecKind for SpecMeasurement<SuperResolution, L> {
@@ -571,11 +564,13 @@ pub fn run_spectrum<V, U, Y>(mut pack: V, ns: U, my_settings: Settings, frame_td
         },
         2 => {
             let measurement = kind.gen16(&my_settings);
-            //build_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, measurement)?;
+            let tdc = measurement.build_aux_tdc(&mut pack);
+            build_spectrum(pack, ns, my_settings, frame_tdc, tdc, measurement)?;
         },
         4 => {
             let measurement = kind.gen32(&my_settings);
-            //build_spectrum(pack, ns, my_settings, frame_tdc, np_tdc, measurement)?;
+            let tdc = measurement.build_aux_tdc(&mut pack);
+            build_spectrum(pack, ns, my_settings, frame_tdc, tdc, measurement)?;
         },
         _ => {return Err(Tp3ErrorKind::SetByteDepth)},
     }


### PR DESCRIPTION
Speclib now has types in the speckind trait. This means we have bounded the combinations between different types and measurements and the auxiliar tdc used. A little bit more automatic and safe